### PR TITLE
Fix for arrows leftovers

### DIFF
--- a/UI/Choosers/TradeRouteChooser.lua
+++ b/UI/Choosers/TradeRouteChooser.lua
@@ -1046,7 +1046,7 @@ function Close()
     LuaEvents.TradeRouteChooser_SetTradeUnitStatus("");
     ContextPtr:SetHide(true);
     m_isOpen = false;
-	UILens.ClearLayerHexes(m_TradeRouteLens); -- fix for route arrows sometimes remaining on the map
+    UILens.ClearLayerHexes(m_TradeRouteLens); -- fix for route arrows sometimes remaining on the map
     if UILens.IsLensActive(m_TradeRouteLens) then
         -- Make sure to switch back to default lens
         UILens.SetActive("Default");

--- a/UI/Choosers/TradeRouteChooser.lua
+++ b/UI/Choosers/TradeRouteChooser.lua
@@ -1046,7 +1046,7 @@ function Close()
     LuaEvents.TradeRouteChooser_SetTradeUnitStatus("");
     ContextPtr:SetHide(true);
     m_isOpen = false;
-
+	UILens.ClearLayerHexes(m_TradeRouteLens); -- fix for route arrows sometimes remaining on the map
     if UILens.IsLensActive(m_TradeRouteLens) then
         -- Make sure to switch back to default lens
         UILens.SetActive("Default");


### PR DESCRIPTION
Sometimes trade route arrows remain on the map. This is a simple fix to remove that annoying effect. Courtesy of @JamieNyanchi.