### PR TITLE
Dynamically get base turn duration for trade routes

### DIFF
--- a/UI/TradeSupport.lua
+++ b/UI/TradeSupport.lua
@@ -1121,7 +1121,8 @@ function GetTripsRequiredFromTradePathLength(tradePathLength:number)
     -- Previous formula that is semi correct
     -- local tripsToDestination = 1 + math.floor(iSpeedCostMultiplier/tradePathLength * 0.1);
     -- NOTE: Not 100% sure of this formula. Ran a few experiments and it seems to be this one
-    local iMinTurnsRequired = (math.floor(iSpeedCostMultiplier * 0.1) * 2.0) + 1
+    local iTurnDurationBase = GameInfo.GlobalParameters["TRADE_ROUTE_TURN_DURATION_BASE"].Value;
+    local iMinTurnsRequired = (math.floor(iTurnDurationBase * (iSpeedCostMultiplier / 100.0))) + 1;
 
     -- Expansion 2 added a modifier called TradeRouteMinimumEndTurnChange that changes required turns based on Era
     if GameInfo.Eras_XP2 ~= nil then


### PR DESCRIPTION
When calculating the duration of trade routes, dynamically get the base turn duration instead of using a hardcoded value of 20. Rewrote the formula slightly to divide `iSpeedCostMultiplier` by 100 instead of 10, as this variable is a percentage multiplier.

This allows BTS to show the correct values when using mods that change the base duration length. I use both BTS and a mod that reduces the base duration length, and this change seems to work perfect.

Let me know if you have any comments or questions!